### PR TITLE
fix: script stop 옵션 제거, collabohub 디렉토리 클론 로직 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,9 +49,19 @@ jobs:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USERNAME }}
           key: ${{ secrets.EC2_PRIVATE_KEY }}
-          script_stop: true
           script: |
-            cd ~/collabohub
+            echo "현재 위치: $(pwd)"
+            
+            cd ~
+            echo "홈 디렉토리로 cd ~ 이동 후 현재 위치: $(pwd)"
+
+            if [ ! -d collabohub ]; then
+                git clone https://github.com/miso1105/CollaboHub.git collabohub
+              fi
+
+            cd collabohub
+            echo "프로젝트 디렉토리로 cd collabohub 이동 후 현재위치: $(pwd)"
+
             docker compose pull collabohub-server
             docker compose down
             docker compose up -d     


### PR DESCRIPTION
## 연관된 이슈
> #20 
## 작업 내용
- appleboy/ssh-action 배포 스텝에서 script_stop 제거

- SSH 스크립트에서 collabohub 폴더가 없을 때 git clone 하는 if 문 추가

## 이슈 링크
- [CollaboHub #20](https://github.com/miso1105/CollaboHub/issues/20) 
