### PR TITLE
fix: GitHub 토큰으로 EC2에서 프라이빗 리포지토리 접근 허용

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,6 +49,7 @@ jobs:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USERNAME }}
           key: ${{ secrets.EC2_PRIVATE_KEY }}
+          envs: CI_CD_GITHUB_TOKEN=${{ secrets.CI_CD_GITHUB_TOKEN }}
           script: |
             echo "현재 위치: $(pwd)"
             
@@ -56,7 +57,7 @@ jobs:
             echo "홈 디렉토리로 cd ~ 이동 후 현재 위치: $(pwd)"
 
             if [ ! -d collabohub ]; then
-                git clone https://github.com/miso1105/CollaboHub.git collabohub
+                git clone https://${CI_CD_GITHUB_TOKEN}@github.com/miso1105/CollaboHub.git collabohub
               fi
 
             cd collabohub


### PR DESCRIPTION
## 연관된 이슈
> #20 
## 작업 내용
- GitHub CI/CD 전용 토큰 생성

- CD 배포 로직 수정

## 이슈 링크
- [CollaboHub #20](https://github.com/miso1105/CollaboHub/issues/20) 
