### PR TITLE
fix: MySQL 컨테이너 healthcheck 대기시간 수정 및 .env 변수 수정

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -3,13 +3,6 @@ services:
     image: 027136969532.dkr.ecr.ap-northeast-2.amazonaws.com/collabohub-server:latest
     env_file:
       - .env
-    environment:
-      - MYSQL_PORT=${MYSQL_PORT}
-      - MYSQL_USER=${MYSQL_USER}
-      - MYSQL_ROOT_PASSWORD=${MYSQL_PASSWORD}
-      - MYSQL_DATABASE=${MYSQL_DATABASE}
-      - REDIS_HOST=${REDIS_HOST}
-      - REDIS_PORT=${REDIS_PORT}
     ports: 
       - 3000:3000
     depends_on:
@@ -24,9 +17,6 @@ services:
     env_file:
       - .env
     environment:
-      - MYSQL_HOST=mysql-db
-      - MYSQL_PORT=${MYSQL_PORT}
-      - MYSQL_USER=${MYSQL_USER}
       - MYSQL_PASSWORD=${MYSQL_PASSWORD}
       - MYSQL_DATABASE=${MYSQL_DATABASE}
     volumes:
@@ -35,8 +25,10 @@ services:
       - 3306:3306
     healthcheck:
       test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
-      interval: 5s
-      retries: 10
+      interval: 10s
+      timeout: 5s
+      retries: 20
+      start_period: 30s
     restart: always
 
   redis-db:


### PR DESCRIPTION
## 연관된 이슈
> #20 

## 작업 내용
- compose.yml: 부팅 지연으로 인한 unhealthy 상태 개선을 위해 대기시간 증가, MySQL 환경변수 키 수정

## 이슈 링크
- [CollaboHub #20](https://github.com/miso1105/CollaboHub/issues/20) 
